### PR TITLE
adding basic appveyor CI build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "CVPZ.Core"]
 	path = CVPZ.Core
-	url = git@github.com:SouthSoundDevelopers/CVPZ.Core.git
+	url = https://github.com/SouthSoundDevelopers/CVPZ.Core.git
 	branch = master
 [submodule "CVPZ.WebUI"]
 	path = CVPZ.WebUI
-	url = git@github.com:SouthSoundDevelopers/CVPZ.WebUI.git
+	url = https://github.com/SouthSoundDevelopers/CVPZ.WebUI.git
 	branch = master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CVPZ [![Build status](__updateme__)](https://ci.appveyor.com/project/SouthSoundDevelopers/CVPZ)
+# CVPZ [![Build status](https://ci.appveyor.com/api/projects/status/f6dsi6lrj7quip37?svg=true)](https://ci.appveyor.com/project/SouthSoundDevelopers/CVPZ)
 
 CV for [Curriculum Vitae](https://en.wikipedia.org/wiki/Curriculum_vitae) is a written overview of a person's experience and other qualifications for a job opportunity.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,9 @@ configuration:
 
 platform: Any CPU
 
+install:
+  - git submodule update --init --recursive
+
 before_build:
   nuget restore
 


### PR DESCRIPTION
Resolves #5 

Once this PR is accepted, someone needs to enable the build on [AppVeyor](https://www.appveyor.com/) and change the __updateme__ link to the correct link. AppVeyor will generate the link for you at the end of the process to enable the project.

AppVeyor can also update the config to execute unit tests, then publish to a host as well as run builds on PRs totally free as long as the project is public.

The owner of the SouthSoundDevelopers needs to enable the builds via AppVeyor.