### PR TITLE
updated build status badge to only display master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CVPZ [![Build status](https://ci.appveyor.com/api/projects/status/m9msqx3io0btxx28?svg=true)](https://ci.appveyor.com/project/McLeopold/cvpz)
+# CVPZ [![Build status](https://ci.appveyor.com/api/projects/status/m9msqx3io0btxx28/branch/master?svg=true)](https://ci.appveyor.com/project/McLeopold/cvpz/branch/master)
 
 CV for [Curriculum Vitae](https://en.wikipedia.org/wiki/Curriculum_vitae) is a written overview of a person's experience and other qualifications.
 


### PR DESCRIPTION
The AppVeyor build status badge currently shows the status for the latest build for all branches. The badge should only show the status of the master branch.