### PR TITLE
Add docker_up.sh, docker_down.sh, and services_ping.sh - Documentation Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,4 @@ ModelManifest.xml
 #Databases
 
 /data/db/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## Who
 
-CVPZ is a community project created by the South Sound Developers User Group ([SSDUG](http://ssdug.org)) in lovely [Olympia, WA](http://olympiawa.gov/). The group is led by [Eve Ragins](https://github.com/orgs/ssdug/people/emragins) and this project was started and led by [Carter Barnes](https://github.com/orgs/ssdug/people/CarBar).
+CVPZ is a community project created by the South Sound Developers User Group ([SSDUG](http://ssdug.org)) in lovely [Olympia, WA](http://olympiawa.gov/). The group is led by [Eve Ragins](https://github.com/emragins) and this project was started and led by [Carter Barnes](https://github.com/CarBar).
 
 ## What
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ By having one common goal to work toward, we will share ideas and continually mo
 1. Change directory into the cloned repository `cd CVPZ`.
 1. Restore packages: `dotnet restore .\CVPZ.sln`.
 1. Open the project in VSCode `code-insiders .` or `code .` depending on what version you chose to install.
+    - Note: On Mac OS: after installing, open up VS Code, Press: Command + Shift + P and then type in and select `Shell Command : Install 'code' command in PATH`.  This will enable you to open VS Code from Terminal with the `code .` command.
 
 
 ### Running Locally from PowerShell

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ By having one common goal to work toward, we will share ideas and continually mo
 
 **Note:** Docker is configured to expose ports for each service, so the local_ping scripts works for both workflows.
 
+### Running Under Docker from Bash
+
+1. Ensure Docker for Mac/Linux is running and set to Linux containers.
+1. Open Terminal.
+1. Change directory into the cloned repository `cd CVPZ`.
+1. Execute the command `./scripts/docker_up.sh -r -b`.
+	- This will build the project and start all services running in the background.
+1. Execute the command `./scripts/local_ping.sh`
+	- This will hit the `api/health/ping` endpoint on all services.
+1. To shut down the image, execute the command `./scripts/docker_down.sh`
+
+**Note:** Docker is configured to expose ports for each service, so the local_ping scripts works for both workflows.
+**Additional Note:** These Bash scripts are run with the sudo command, so you may be prompted for your password when running them.
+
+
 ### Running Under Docker from Visual Studio 2017
 
 1. Ensure Docker for Windows is running and set to Linux containers.

--- a/scripts/docker_down.sh
+++ b/scripts/docker_down.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo docker-compose down

--- a/scripts/docker_up.sh
+++ b/scripts/docker_up.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+rebuild=false
+background=false
+
+for args in "$@"
+do
+    if [ $args = "-r" ]; then
+        rebuild=true
+    fi
+    if [ $args = "-b" ]; then
+        background=true
+    fi
+done
+
+if [ $rebuild = true ]; then
+    sudo docker-compose -f ./docker-compose.ci.build.yml up
+fi
+
+if [ $background = true ]; then
+    sudo docker-compose -f ./docker-compose.yml -f ./docker-compose.override.yml up -d --build
+else
+    sudo docker-compose -f ./docker-compose.yml -f ./docker-compose.override.yml up --build
+fi

--- a/scripts/services_ping.sh
+++ b/scripts/services_ping.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+host_url="http://localhost"
+
+hostUrls=("$host_url:5001/api/health/ping" "$host_url:5002/api/health/ping" "$host_url:5003/api/health/ping" "$host_url:5001/.well-known/openid-configuration" )
+for i in "${hostUrls[@]}"
+do
+	curl $i
+    echo ""
+done


### PR DESCRIPTION
Added Bash Scripts to better align with their PowerShell equivalents: docker_up.sh which is a bash version of docker_up.ps1 script, taking in -r and -b commands. docker_down.sh which is a bash version of docker_down.ps1.  services_ping.sh which is a bash version of services_ping.ps1.  

Additionally, updated README documentation to show how to run under docker using Terminal and Bash on Mac or Linux.

Please let me know if there are any changes you'd recommend to improve them